### PR TITLE
fix reminders sometimes duplicating

### DIFF
--- a/src/main/java/com/bloodpressuremonitor/group4/csc325_group4/view/DashboardView.java
+++ b/src/main/java/com/bloodpressuremonitor/group4/csc325_group4/view/DashboardView.java
@@ -40,37 +40,42 @@ public class DashboardView {
 */
 package com.bloodpressuremonitor.group4.csc325_group4.view;
 
-import com.bloodpressuremonitor.group4.csc325_group4.model.BloodPressureReading;
-import com.bloodpressuremonitor.group4.csc325_group4.session.Session;
-import com.bloodpressuremonitor.group4.csc325_group4.session.SessionManager;
-import javafx.animation.FadeTransition;
-import javafx.animation.PauseTransition;
-import javafx.application.Platform;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.collections.FXCollections;
-import javafx.event.ActionEvent;
-import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
-import javafx.scene.control.*;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
-
-import com.google.api.core.ApiFuture;
-import com.google.cloud.firestore.DocumentReference;
-import com.google.cloud.firestore.DocumentSnapshot;
-import javafx.stage.FileChooser;
-import javafx.stage.Stage;
-import javafx.util.Duration;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import com.bloodpressuremonitor.group4.csc325_group4.model.BloodPressureReading;
+import com.bloodpressuremonitor.group4.csc325_group4.session.Session;
+import com.bloodpressuremonitor.group4.csc325_group4.session.SessionManager;
+import com.bloodpressuremonitor.group4.csc325_group4.viewmodel.AccessDataViewModel;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+
+import javafx.animation.FadeTransition;
+import javafx.animation.PauseTransition;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+import javafx.util.Duration;
 
 public class DashboardView {
 
@@ -93,13 +98,17 @@ public class DashboardView {
 
     private boolean isMenuOpen = false;
     private Session session;
+    
 
     @FXML
     public void initialize() {
         session = SessionManager.getSession();
-        showLoginPopup(); // show reminder after login
-        scheduleDailyReminder(); // schedule reminder
-
+        //for first time login, show a reminder as well as schedule a popup reminder
+        if(AccessDataViewModel.firstLaunch()){
+            showLoginPopup(); // show reminder after login
+            scheduleDailyReminder(); // schedule popup reminder
+            AccessDataViewModel.setFirstLaunch(false);
+        }
         VBox.setVgrow(tableView, Priority.ALWAYS);
         tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
 

--- a/src/main/java/com/bloodpressuremonitor/group4/csc325_group4/viewmodel/AccessDataViewModel.java
+++ b/src/main/java/com/bloodpressuremonitor/group4/csc325_group4/viewmodel/AccessDataViewModel.java
@@ -1,5 +1,13 @@
 package com.bloodpressuremonitor.group4.csc325_group4.viewmodel;
 
 public class AccessDataViewModel {
-//TODO
+
+    //store data for first time login popups
+    private static boolean first = true;
+    public static boolean firstLaunch(){
+        return first;
+    }
+    public static void setFirstLaunch(boolean f){
+        first = f;
+    }
 }


### PR DESCRIPTION
Reminders would get reset upon switching back to dashboard from the chart menu, including setting a duplicate timer that would cause multiple popups if switching to and from the chart more than once