### PR TITLE
make all windows a consistent size

### DIFF
--- a/src/main/resources/files/LoginView.fxml
+++ b/src/main/resources/files/LoginView.fxml
@@ -12,9 +12,9 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.bloodpressuremonitor.group4.csc325_group4.view.LoginView">
+<AnchorPane prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.bloodpressuremonitor.group4.csc325_group4.view.LoginView">
    <children>
-      <BorderPane prefHeight="428.0" prefWidth="632.0">
+      <BorderPane prefHeight="428.0" prefWidth="832.0">
          <center>
             <VBox alignment="CENTER" prefHeight="200.0" prefWidth="100.0" spacing="20.0" BorderPane.alignment="CENTER">
                <children>
@@ -35,7 +35,7 @@
             </HBox>
          </bottom>
          <top>
-            <Label alignment="CENTER" contentDisplay="CENTER" prefHeight="72.0" prefWidth="271.0" text="Blood Pressure Tracker" textAlignment="CENTER" textFill="#0044ff" BorderPane.alignment="CENTER">
+            <Label alignment="CENTER" contentDisplay="CENTER" prefHeight="272.0" prefWidth="271.0" text="Blood Pressure Tracker" textAlignment="CENTER" textFill="#0044ff" BorderPane.alignment="CENTER">
                <font>
                   <Font size="20.0" />
                </font>

--- a/src/main/resources/files/SignUpView.fxml
+++ b/src/main/resources/files/SignUpView.fxml
@@ -11,9 +11,9 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.bloodpressuremonitor.group4.csc325_group4.view.SignUpView">
+<AnchorPane prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.bloodpressuremonitor.group4.csc325_group4.view.SignUpView">
    <children>
-      <BorderPane prefHeight="420.0" prefWidth="651.0">
+      <BorderPane prefHeight="420.0" prefWidth="851.0">
          <bottom>
             <HBox alignment="CENTER" prefHeight="100.0" prefWidth="200.0" spacing="20.0" BorderPane.alignment="CENTER">
                <children>
@@ -37,7 +37,7 @@
             </VBox>
          </center>
          <top>
-            <Label alignment="CENTER" prefHeight="76.0" prefWidth="385.0" text="Blood Pressure Monitoring System Sign Up" textAlignment="CENTER" translateY="15.0" BorderPane.alignment="CENTER">
+            <Label alignment="CENTER" prefHeight="176.0" prefWidth="385.0" text="Blood Pressure Monitoring System Sign Up" textAlignment="CENTER" translateY="15.0" BorderPane.alignment="CENTER">
                <font>
                   <Font size="20.0" />
                </font></Label>


### PR DESCRIPTION
make all windows default to a size that allows chart to be fully on screen by default instead of having to manually resize it